### PR TITLE
AP-9 user setting feature

### DIFF
--- a/src/components/admin/account/PasswordVisibilityToggle.jsx
+++ b/src/components/admin/account/PasswordVisibilityToggle.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import eyeIcon from '../../../assets/svg/eye.svg';
+import eyeHideIcon from '../../../assets/svg/eye-hide.svg';
+
+const PasswordVisibilityToggle = ({ onToggle }) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
+    onToggle(!showPassword); // Pass the updated showPassword value to the parent component
+  };
+
+  return (
+    <span onClick={togglePasswordVisibility}>
+      {showPassword ? (
+        <img src={eyeHideIcon} alt="hide password" />
+      ) : (
+        <img src={eyeIcon} alt="show password" />
+      )}
+    </span>
+  );
+};
+
+export default PasswordVisibilityToggle;

--- a/src/pages/admin/account/Account.jsx
+++ b/src/pages/admin/account/Account.jsx
@@ -2,13 +2,132 @@ import React, { useState } from 'react';
 import './account.scss';
 import Header from '../../../components/admin/header/Header';
 import Footer from '../../../components/footer/Footer';
-import eyeIcon from '../../../assets/svg/eye.svg';
-import eyeHideIcon from '../../../assets/svg/eye-hide.svg';
+import PasswordVisibilityToggle from '../../../components/admin/account/PasswordVisibilityToggle';
+
+// Firebase import section
+import { auth, db } from "../../../firebase"
+// Firebase SDK to update the personal info fields in the Firestore
+import { doc, updateDoc } from 'firebase/firestore';
+// Firebase SDK to update to a new email
+// Firebase SDK to re-authenticate user when changing password
+import { updateEmail, reauthenticateWithCredential, updatePassword, EmailAuthProvider} from 'firebase/auth';
 
 const Account = () => {
+
+  async function updateUserInfo(uid, updates) {
+    const userRef = doc(db, "users", uid);
+    await updateDoc(userRef, updates);
+  }
+
+  async function updateUserEmail(user, newEmail) {
+    await updateEmail(user, newEmail);
+  }
+
+  async function updateUserPassword(user, currentPassword, newPassword) {
+    const credential = EmailAuthProvider.credential(
+      user.email,
+      currentPassword
+    );
+    await reauthenticateWithCredential(user, credential);
+    await updatePassword(user, newPassword);
+  }
+
+// User information update states
+  // New personal info
+  const [personalInfo, setPersonalInfo] = useState({
+    firstName: '',
+    lastName: '',
+    phoneNumber: '',
+  });
+
+  // New email
+  const [email, setEmail] = useState('');
+
+  // New password
+  const [password, setPassword] = useState({
+    currentConfirmationPassword: '',
+    currentPassword: '',
+    newPassword: '',
+    newConfirmationPassword: '',
+  });
+
+  // Error states
+  const [personalInfoError, setPersonalInfoError] = useState(null);
+  const [emailError, setEmailError] = useState(null);
+  const [passwordError, setPasswordError] = useState(null);
+
+  const handlePersonalInfoSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const user = auth.currentUser;
+      if (user) {
+        const uid = user.uid;
+        const userRef = doc(db, 'users', uid);
+        await updateDoc(userRef, {
+          firstName: personalInfo.firstName,
+          lastName: personalInfo.lastName,
+          phoneNumber: personalInfo.phoneNumber,
+        });
+        setPersonalInfoError(null);
+        alert('Personal information updated!');
+      }
+    } catch (err) {
+      console.log(err);
+      setPersonalInfoError('An error occurred while updating your personal information.');
+    }
+  };
+
+  const handleEmailSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const user = auth.currentUser;
+      if (user) {
+        const credential = EmailAuthProvider.credential(user.email, password);
+        await reauthenticateWithCredential(user, credential);
+        await updateEmail(user, email);
+        setEmailError(null);
+        alert('Email address updated!');
+      }
+    } catch (err) {
+      console.log(err);
+      setEmailError('An error occurred while updating your email address.');
+    }
+  };
+
+  const handlePasswordSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      if (!passwordMatch) {
+        setPasswordError('Passwords do not match');
+        return;
+      }
+      const user = auth.currentUser;
+      if (user) {
+        const credential = EmailAuthProvider.credential(user.email, password.currentPassword);
+        await reauthenticateWithCredential(user, credential);
+        await updatePassword(user, password.newPassword);
+        setPassword({
+          currentConfirmationPassword: '',
+          currentPassword: '',
+          newPassword: '',
+          newConfirmationPassword: '',
+        });
+        setPasswordError(null);
+        alert('Password updated!');
+      }
+    } catch (err) {
+      console.log(err);
+      setPasswordError('An error occurred while updating your password.');
+    }
+  };
+
+  // Password visibility states
   const [showCurrentPassword, setShowCurrentPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmationPassword, setShowConfirmationPassword] = useState(false);
+  const [showNewConfirmationPassword, setShowNewConfirmationPassword] = useState(false);
 
+  // Password visibility
   const toggleCurrentPasswordVisibility = () => {
     setShowCurrentPassword(!showCurrentPassword);
   };
@@ -16,6 +135,39 @@ const Account = () => {
   const toggleNewPasswordVisibility = () => {
     setShowNewPassword(!showNewPassword);
   };
+
+  const toggleConfirmationPasswordVisibility = () => {
+    setShowConfirmationPassword(!showConfirmationPassword);
+  };
+
+  const toggleNewConfirmationPasswordVisibility = () => {
+    setShowNewConfirmationPassword(!showNewConfirmationPassword);
+  };
+
+  // Check if new passwords match
+  const [passwordMatch, setPasswordMatch] = useState(false);
+
+  const handleNewPasswordChange = (e) => {
+    setPassword((prevState) => ({
+      ...prevState,
+      newPassword: e.target.value,
+    }));
+
+    setPasswordMatch(password.newConfirmationPassword === e.target.value);
+  };
+
+  const handleNewConfirmationPasswordChange = (e) => {
+    setPassword((prevState) => ({
+      ...prevState,
+      newConfirmationPassword: e.target.value,
+    }));
+
+    setPasswordMatch(password.newPassword === e.target.value);
+  };
+
+
+
+
 
   return (
     <>
@@ -28,7 +180,7 @@ const Account = () => {
 
       <div className="account-section">
 
-        <form action="" className="account-form">
+        <form onSubmit={handlePersonalInfoSubmit} className="account-form">
           <h3>Personal Information</h3>
           <hr />
 
@@ -38,18 +190,45 @@ const Account = () => {
 
               <div className="account-info">
                 <label htmlFor="fname">FIRST NAME</label>
-                <input type="text" id='fname'/>
+                <input
+                type="text"
+                id='fname'
+                value={personalInfo.firstName}
+                onChange={(e) =>
+                  setPersonalInfo({
+                    ...personalInfo,
+                    firstName: e.target.value })
+                }
+              />
               </div>
 
               <div className="account-info">
                 <label htmlFor="lname">LAST NAME</label>
-                <input type="text" id='lname'/>
+                <input
+                type="text"
+                id='lname'
+                value={personalInfo.lastName}
+                onChange={(e) =>
+                  setPersonalInfo({
+                    ...personalInfo,
+                    lastName: e.target.value })
+                }
+                />
               </div>
             </div>
 
             <div className="account-info">
               <label htmlFor="pnum">PHONE NUMBER</label>
-              <input type="number" id='pnum'/>
+              <input
+              type="number"
+              id='pnum'
+              value={personalInfo.phoneNumber}
+              onChange={(e) =>
+                setPersonalInfo({
+                  ...personalInfo,
+                  phoneNumber: e.target.value })
+                }
+              />
               <div className='num-reminder'>
                 <p>Keep 11-digit format with no spaces and dashes</p>
               </div>
@@ -60,61 +239,90 @@ const Account = () => {
               <button type="submit">Save</button>
           </div>
         </form>
+        {personalInfoError && <p>{personalInfoError}</p>} {/* Display error message if an error occurred */}
 
-        <form action="" className="account-form">
+        <form onSubmit={handleEmailSubmit} className="account-form">
           <h3>E-mail Address</h3>
           <hr />
 
-          <div className="acc-info-container">
+          <div className="email-info-container">
 
-            <div className="account-info">
+            <div className="email-info">
               <label htmlFor="email">E-MAIL ADDRESS</label>
-              <input type="text" id='email'/>
+              <input
+                type="email"
+                id='email'
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
             </div>
+
+            <div className="account-input-field">
+              <label htmlFor="confirmationpass">CONFIRM PASSWORD</label>
+              <input
+                type={showConfirmationPassword ? "text" : "password"}
+                id="confirmationpass"
+                value={password.currentConfirmationPassword}
+                onChange={(e) => setPassword({ ...password, currentConfirmationPassword: e.target.value })}
+              />
+              <PasswordVisibilityToggle onToggle={toggleConfirmationPasswordVisibility} />
+            </div>
+
 
           </div>
           <div className="account-save-btn">
               <button type="submit">Save</button>
           </div>
         </form>
+        {emailError && <p>{emailError}</p>} {/* Display error message if an error occurred */}
 
-        <form action="" className="account-form">
+        <form onSubmit={handlePasswordSubmit} className="account-form">
           <h3>Password</h3>
           <hr />
 
           <div className="password-info-container">
+            <div className="account-input-field">
+              <label htmlFor="currpass">CURRENT PASSWORD</label>
+              <input
+                type={showCurrentPassword ? "text" : "password"}
+                id="currpass"
+                value={password.currentPassword}
+                onChange={(e) =>
+                  setPassword({
+                    ...password,
+                    currentPassword: e.target.value,
+                  })
+                }
+              />
+              <PasswordVisibilityToggle onToggle={toggleCurrentPasswordVisibility} />
+            </div>
 
-          <div className="account-input-field">
-            <label htmlFor="currpass">CURRENT PASSWORD</label>
-            <input
-              type={showCurrentPassword ? "text" : "password"}
-              id="currpass"
-            />
-            <span onClick={toggleCurrentPasswordVisibility}>
-              {showCurrentPassword ? (
-                <img src={eyeHideIcon} alt="hide password" />
-              ) : (
-                <img src={eyeIcon} alt="show password" />
-              )}
-            </span>
-          </div>
+            <div className="account-input-field">
+              <label htmlFor="newpass">NEW PASSWORD</label>
+              <input
+              type={showNewPassword ? "text" : "password"}
+              id="newpass"
+              value={password.newPassword}
+              onChange={handleNewPasswordChange}
+              />
+              <PasswordVisibilityToggle onToggle={toggleNewPasswordVisibility} />
+            </div>
 
-          <div className="account-input-field">
-            <label htmlFor="newpass">NEW PASSWORD</label>
-            <input type={showNewPassword ? "text" : "password"} id="newpass" />
-            <span onClick={toggleNewPasswordVisibility}>
-              {showNewPassword ? (
-                <img src={eyeHideIcon} alt="hide password" />
-              ) : (
-                <img src={eyeIcon} alt="show password" />
-              )}
-            </span>
-          </div>
-
-          <div className="account-input-field">
-            <label htmlFor="confirmpass">CONFIRM PASSWORD</label>
-            <input type="password" id="confirmpass" />
-          </div>
+            <div className="account-input-field">
+              <label htmlFor="confirmnewpass">CONFIRM NEW PASSWORD</label>
+              <input
+              type ={showNewConfirmationPassword ? "text" : "password"}
+              id="confirmnewpass"
+              value={password.newConfirmationPassword}
+              onChange={handleNewConfirmationPasswordChange}
+              />
+              <PasswordVisibilityToggle onToggle={toggleNewConfirmationPasswordVisibility} />
+              <div className='password-matching'>
+                {password.newConfirmationPassword && !passwordMatch && (
+                  <p>Passwords do not match</p>
+                )}
+              </div>
+            </div>
 
         </div>
 
@@ -122,6 +330,8 @@ const Account = () => {
               <button type="submit">Save</button>
           </div>
         </form>
+        {passwordError && <p>{passwordError}</p>} {/* Display error message if an error occurred */}
+
       </div>
     </div>
 

--- a/src/pages/admin/account/account.scss
+++ b/src/pages/admin/account/account.scss
@@ -107,6 +107,35 @@
     }
   }
 
+.email-info-container {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 4vh;
+
+  .email-info {
+    margin-top: 2em;
+    margin-right: auto;
+    position: relative;
+
+    label {
+      display: block;
+      text-align: left;
+      margin-bottom: 0.5em;
+      font-size: small;
+      font-weight: bold;
+    }
+
+    input {
+      width: 100%;
+      height: 2.5em;
+      text-align: left;
+      border-radius: 5px;
+      border: solid 1px var(--martinique);
+      padding: 0 1.3em 0 0.8em;
+      font-size: medium;
+    }
+  }
+}
 
 .password-info-container {
     display: flex;
@@ -115,57 +144,67 @@
     width: 100%;
     margin-bottom: 4vh;
 
-    .account-input-field {
-        display: flex;
-        flex-direction: column;
-        margin-top: 2em;
-        margin-right: auto;
-        position: relative;
-
-        label {
-            display: block;
-            text-align: left;
-            margin-bottom: 0.5em;
-            font-size: small;
-            font-weight: bold;
-        }
-
-        input {
-            width: 100%;
-            height: 2.5em;
-            text-align: left;
-            border-radius: 5px;
-            border: solid 1px var(--martinique);
-            padding: 0 2.2em 0 0;
-            font-size: medium;
-            text-indent: 4%;
-        }
-
-        span {
-            width: 1.1em;
-            height: 1.2em;
-            position: absolute;
-            z-index: 200;
-            top: 1.9em;
-            right: 0.6em;
-            cursor: pointer;
-        }
-
-
-        // outline: 1px solid red;
-    }
-
     // outline: 1px solid red;
 }
 
-.num-reminder {
-    margin-top: 0.5em;
-    p {
-        font-size: small;
-        text-align: left;
-        color: var(--loblolly);
-    }
+.account-input-field {
+  display: flex;
+  flex-direction: column;
+  margin-top: 2em;
+  margin-right: auto;
+  position: relative;
+
+  label {
+      display: block;
+      text-align: left;
+      margin-bottom: 0.5em;
+      font-size: small;
+      font-weight: bold;
   }
+
+  input {
+      width: 100%;
+      height: 2.5em;
+      text-align: left;
+      border-radius: 5px;
+      border: solid 1px var(--martinique);
+      padding: 0 2.2em 0 0;
+      font-size: medium;
+      text-indent: 4%;
+  }
+
+  span {
+      width: 1.1em;
+      height: 1.2em;
+      position: absolute;
+      z-index: 200;
+      top: 1.9em;
+      right: 0.6em;
+      cursor: pointer;
+  }
+
+
+  // outline: 1px solid red;
+}
+
+.num-reminder {
+  margin-top: 0.5em;
+  p {
+      font-size: small;
+      text-align: left;
+      color: var(--loblolly);
+  }
+}
+
+.password-matching {
+  margin-top: 0.5em;
+  p {
+    font-size: small;
+    font-weight: bold;
+    text-align: left;
+    color: #D72638;
+}
+}
 
 .account-save-btn {
     text-align: left;


### PR DESCRIPTION
- Added backend integration. Now the page allows the user to update their personal information, email, and password, and independently from each other (meaning the user can choose to update either of the three or all of them).
- For enhanced security, the user cannot update their email unless the user confirms their password. So, an extra `CONFIRM PASSWORD` field is added.
- Added a feature that ensures that the password inputs in the `NEW PASSWORD` field and `CONFIRM NEW PASSWORD` field match, otherwise an error is shown.
- To make the code readable, I separated the password visibility toggle into its own component.

Issues: 
- the new features still need to undergo testing
- the codes need to be cleaned (in their current state, it is very messy and hard to read). My suggestions: separate the codes into components, if applicable.