### PR TITLE
increased the width of listing-img container from 100% to 121% (for listings w/o photos)

### DIFF
--- a/src/components/explore/listing/listing.scss
+++ b/src/components/explore/listing/listing.scss
@@ -28,7 +28,7 @@
         // Add conditional class based on accommodation.photos
         // If a listing has no photo, the following is applied
         &.no-photos {
-            width: 100%;
+            width: 121%;
             height: 15em;
         }
 


### PR DESCRIPTION
The purpose of this commit is to align the right edge of the empty image container with the edges of listings contained with an image.